### PR TITLE
Bugfix extraction logs

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -99,6 +99,7 @@ class Oletools(ServiceBase):
         self.all_pcode = None
         self.extracted_clsids = None
         self.patterns = None
+        self.excess_extracted = None
         self.vba_stomping = False
 
     def start(self):
@@ -351,6 +352,7 @@ class Oletools(ServiceBase):
         self.all_macros = []
         self.all_vba = []
         self.all_pcode = []
+        self.excess_extracted = []
 
         self.vba_stomping = False
 
@@ -385,6 +387,8 @@ class Oletools(ServiceBase):
                 section = ResultSection("Error deep parsing: {str(e)}")
                 request.result.add_section(section)
 
+        if self.excess_extracted:
+            self.log.error(f"Too many files extracted for sample {self.sha}. {len(self.excess_extracted)} files were not extracted")
         # score_check = 0
         # for section in self.ole_result.sections:
         #     score_check += self.calculate_nested_scores(section)
@@ -562,6 +566,8 @@ class Oletools(ServiceBase):
 
                                 self.request.add_extracted(xml_file_path, xml_sha256, f"zipped file {f} contents")
                                 xml_extracted.add(xml_sha256)
+                            except MaxExtractedExceeded:
+                                self.excess_extracted.append(xml_sha256)
                             except Exception as e:
                                 self.log.error(f"Error while adding extracted content {xml_file_path} for "
                                                f"sample {self.sha}: {str(e)}")
@@ -1290,6 +1296,8 @@ class Oletools(ServiceBase):
                             mime_res.add_line(part_filename)
                             self.request.add_extracted(part_path, os.path.basename(part_path),
                                                        "ActiveMime x-mso from multipart/related.")
+                        except MaxExtractedExceeded:
+                            self.excess_extracted.append(part_filename)
                         except Exception as e:
                             self.log.error(f"Error submitting extracted file for sample {self.sha}: {str(e)}")
                     except Exception as e:

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -27,6 +27,7 @@ from assemblyline_v4_service.common.balbuzard.patterns import PatternMatch
 from assemblyline_v4_service.common.base import ServiceBase
 from assemblyline_v4_service.common.request import ServiceRequest
 from assemblyline_v4_service.common.result import Result, ResultSection, BODY_FORMAT, Heuristic
+from assemblyline_v4_service.common.task import MaxExtractedExceeded
 
 from oletools_.cleaver import OLEDeepParser
 from oletools_.pcodedmp import process_doc


### PR DESCRIPTION
Fixes a file that extracts too many times logging an error for each extracted file over the limit.
Now logs once per submission with the number of files that could not be extracted.