### PR TITLE
Bugfix xml extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ installation.
 - MACRO_SCORE_MIN_ALERT: Chains.json contains common English trigraphs. We score macros on how common these trigraphs 
 appear in code, skipping over some common keywords. A lower score than this config value indicates more randomized text, 
 and random variable/function names are common in malicious macros. (Default value: 0.6)
-- METADATA_SIZE_TO_EXTRACT: If OLE metadata is larger than this size (in bytes), the service will extract the metadata content as a new file (Default value: 500)  
+- METADATA_SIZE_TO_EXTRACT: If OLE metadata is larger than this size (in bytes), the service will extract the metadata content as a new file (Default value: 500)
+- IOC_PATTERN_SAFELIST: If an IOC contains one of the strings in the list, Oletools will ignore it unless in deep scan mode. (Default value: [])
+- IOC_EXACT_SAFELIST: If an IOC is one of the strings in the list, Oletools will ignore it unless in deep scan mode. (Default value: [])
 
 ## Execution
 

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -151,10 +151,11 @@ class Oletools(ServiceBase):
         # Plain IOCs
         if self.patterns:
             pat_strs = ["http://purl.org", "schemas.microsoft.com", "schemas.openxmlformats.org",
-                        "www.w3.org", "dublincore.org/schemas/"]
+                        "www.w3.org", "dublincore.org/schemas/", "gcdocs.gc.ca"]
             pat_ends = ["themeManager.xml", "MSO.DLL", "stdole2.tlb", "vbaProject.bin", "VBE6.DLL",
                         "VBE7.DLL"]
-            pat_whitelist = ['management', 'manager', 'connect', "microsoft.com", "dublincore.org"]
+            pat_whitelist = ["management", "manager", "connect", "microsoft.com", "dublincore.org", "llisapi.dll"]
+            known_bin = ["sheet", "printerSettings", "queryTable", "binaryIndex", "table"]
 
             patterns_found = self.patterns.ioc_match(data, bogon_ip=True)
             for tag_type, iocs in patterns_found.items():
@@ -164,6 +165,9 @@ class Oletools(ServiceBase):
                     if any(string in ioc for string in pat_strs) \
                             or ioc.endswith(tuple(pat_ends)) \
                             or ioc.lower() in pat_whitelist:
+                        continue
+                    # Skip .bin files that are common in normal excel files
+                    if not self.deep_scan and ioc[-4:] == '.bin' and ioc.startswith(known_bin):
                         continue
                     extract = extract or self.decide_extract(tag_type, ioc)
                     found_tags[tag_type].add(ioc)

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -96,6 +96,7 @@ class Oletools(ServiceBase):
         self.macro_score_min_alert = self.config.get('macro_score_min_alert', 0.6)
         self.metadata_size_to_extract = self.config.get('metadata_size_to_extract', 500)
         self.ioc_pattern_safelist = self.config.get('ioc_pattern_safelist')
+        self.ioc_exact_safelist = self.config.get('ioc_exact_safelist')
 
         self.all_macros = None
         self.all_vba = None
@@ -152,11 +153,14 @@ class Oletools(ServiceBase):
         # Plain IOCs
         if self.patterns:
             pat_strs = ["http://purl.org", "schemas.microsoft.com", "schemas.openxmlformats.org",
-                        "www.w3.org", "dublincore.org/schemas/"] + self.ioc_pattern_safelist
+                        "www.w3.org", "dublincore.org/schemas/"]
             pat_ends = ["themeManager.xml", "MSO.DLL", "stdole2.tlb", "vbaProject.bin", "VBE6.DLL",
                         "VBE7.DLL"]
             pat_whitelist = ["management", "manager", "microsoft.com", "dublincore.org"]
             excel_bin_re = re.compile(r'(sheet|printerSettings|queryTable|binaryIndex|table)\d{1,12}\.bin')
+            if not self.request.deep_scan:
+                pat_strs += self.ioc_pattern_safelist
+                pat_whitelist += self.ioc_exact_safelist
 
             patterns_found = self.patterns.ioc_match(data, bogon_ip=True)
             for tag_type, iocs in patterns_found.items():

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -95,6 +95,7 @@ class Oletools(ServiceBase):
         self.macro_score_max_size = self.config.get('macro_score_max_file_size', None)
         self.macro_score_min_alert = self.config.get('macro_score_min_alert', 0.6)
         self.metadata_size_to_extract = self.config.get('metadata_size_to_extract', 500)
+        self.ioc_pattern_safelist = self.config.get('ioc_pattern_safelist')
 
         self.all_macros = None
         self.all_vba = None
@@ -151,7 +152,7 @@ class Oletools(ServiceBase):
         # Plain IOCs
         if self.patterns:
             pat_strs = ["http://purl.org", "schemas.microsoft.com", "schemas.openxmlformats.org",
-                        "www.w3.org", "dublincore.org/schemas/"]
+                        "www.w3.org", "dublincore.org/schemas/"] + self.ioc_pattern_safelist
             pat_ends = ["themeManager.xml", "MSO.DLL", "stdole2.tlb", "vbaProject.bin", "VBE6.DLL",
                         "VBE7.DLL"]
             pat_whitelist = ["management", "manager", "microsoft.com", "dublincore.org"]
@@ -471,10 +472,6 @@ class Oletools(ServiceBase):
         # When deepscanning, do only minimal whitelisting
         if self.request.deep_scan:
             return True
-
-        # gcdocs links cause these iocs
-        if 'gcdocs.gc.ca' in val or val == 'llisapi.dll':
-            return False
 
         # common false positives
         if ty == 'file.string.api' and val == 'connect':

--- a/oletools_/stream_parser.py
+++ b/oletools_/stream_parser.py
@@ -277,7 +277,7 @@ class PowerPointDoc(object):
 class PowerPointObject(object):
     # noinspection PyBroadException
     def __init__(self, buf):
-        self.rec_ver = struct.unpack("B", buf[0])[0] & 0xF
+        self.rec_ver = buf[0] & 0xF
         self.rec_instance = struct.unpack("<H", buf[:2])[0] >> 4
         self.rec_type = PowerPointDoc.OBJ_TYPES[struct.unpack("<H", buf[2:4])[0]]
         self.rec_length = struct.unpack("<I", buf[4:8])[0]

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -23,6 +23,7 @@ config:
   macro_score_max_file_size: 5242880  # 5 * 1024**2
   macro_score_min_alert: 0.6
   metadata_size_to_extract: 500
+  ioc_pattern_safelist: []
 
 heuristics:
   - heur_id: 1

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -24,6 +24,7 @@ config:
   macro_score_min_alert: 0.6
   metadata_size_to_extract: 500
   ioc_pattern_safelist: []
+  ioc_exact_safelist: []
 
 heuristics:
   - heur_id: 1


### PR DESCRIPTION
Reducing irrelevant xml extractions by whitelisting certain IOCS:
- common excel .bin filenames no longer tagged
- dublincore.org schema urls no longer tagged
- no longer extracting based on iocs found in gcdocs urls
- no longer extracting based on common blacklisted strings

Also fixed a powerpoint parsing error (string bytes problem again)