### PR TITLE
Macro heuristics fixes

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -1157,7 +1157,7 @@ class Oletools(ServiceBase):
                 subsection.set_heuristic(32)
                 for keyword, description in vba_scanner.autoexec_keywords:
                     subsection.add_line(keyword)
-                    subsection.heuristic.add_signature_id(keyword)
+                    subsection.heuristic.add_signature_id(keyword.lower())
                 macro_section.add_subsection(subsection)
 
             if len(vba_scanner.suspicious_keywords) > 0:
@@ -1165,7 +1165,7 @@ class Oletools(ServiceBase):
                 subsection.set_heuristic(30)
                 for keyword, description in vba_scanner.suspicious_keywords:
                     subsection.add_line(keyword)
-                    subsection.heuristic.add_signature_id(keyword)
+                    subsection.heuristic.add_signature_id(keyword.lower())
                 macro_section.add_subsection(subsection)
 
             if len(vba_scanner.iocs) > 0:

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -191,7 +191,8 @@ heuristics:
 
   - heur_id: 27
     name: Found network indicator(s) within macros
-    score: 500
+    score: 50
+    max_score: 500
     filetype: document/office
     description: Found network indicator(s) within macros
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -195,13 +195,6 @@ heuristics:
     filetype: document/office
     description: Found network indicator(s) within macros
 
-  - heur_id: 28
-    name: Potential host or network IOCs
-    score: 50
-    max_score: 500
-    filetype: document/office
-    description: Potential host or network IOCs
-
   - heur_id: 30
     name: Suspicious strings or functions
     score: 50


### PR DESCRIPTION
Fixes for associated tickets AL-1077, AL-1078, AL-1079:
- Combined ioc whitelisting for macros and xml
- Deduplicated redundant heuristics (Oletools.27 and Oletools.28)
- Set string based signatures to lowercase so that signature statistics are consistent