### PR TITLE
Al 1086 adjust vba stomping

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -816,6 +816,7 @@ class Oletools(ServiceBase):
                 stomp_sec.set_heuristic(4)
                 if pcode_matches:
                     stomp_sec.add_line("Suspicious VBA content different in pcode dump than in macro dump content.")
+                    stomp_sec.heuristic.add_signature_id("Suspicious VBA stomped", score=400)
                     pcode_stomp_sec = ResultSection("Pcode dump suspicious content:", parent=stomp_sec)
                     for m in pcode_matches:
                         pcode_stomp_sec.add_line(m)

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -816,7 +816,7 @@ class Oletools(ServiceBase):
                 stomp_sec.set_heuristic(4)
                 if pcode_matches:
                     stomp_sec.add_line("Suspicious VBA content different in pcode dump than in macro dump content.")
-                    stomp_sec.heuristic.add_signature_id("Suspicious VBA stomped", score=400)
+                    stomp_sec.heuristic.add_signature_id("Suspicious VBA stomped", score=500)
                     pcode_stomp_sec = ResultSection("Pcode dump suspicious content:", parent=stomp_sec)
                     for m in pcode_matches:
                         pcode_stomp_sec.add_line(m)

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -52,7 +52,7 @@ heuristics:
 
   - heur_id: 4
     name: VBA Stomping
-    score: 500
+    score: 100
     filetype: document/office
     description: The VBA source code and P-code are different, this may have been used to hide malicious code.
 


### PR DESCRIPTION
Reduce VBA stomping heuristic score to 100 if there are no new mraptor indicators in the pcode.
New signature "Suspicious VBA stomped" maintains score of 500 if new indicators are found.