### PR TITLE
Bug + Log fixes

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -483,6 +483,7 @@ class Oletools(ServiceBase):
             zip_uris = []
             xml_extracted = set()
             extracted_added = 0
+            extract_exceeded = False
             if zipfile.is_zipfile(path):
                 z = zipfile.ZipFile(path)
                 for f in z.namelist():
@@ -512,7 +513,8 @@ class Oletools(ServiceBase):
                         xml_b64_res.add_subsection(f_b64res)
 
                     # all vba extracted anyways
-                    if (extract_ioc or extract_b64 or extract_regex) and not f.endswith("vbaProject.bin"):
+                    if not extract_exceeded and \
+                            (extract_ioc or extract_b64 or extract_regex) and not f.endswith("vbaProject.bin"):
                         xml_sha256 = hashlib.sha256(data).hexdigest()
                         if xml_sha256 not in xml_extracted:
                             xml_file_path = os.path.join(self.working_directory, xml_sha256)
@@ -525,7 +527,7 @@ class Oletools(ServiceBase):
                                 extracted_added += 1
                             except MaxExtractedExceeded:
                                 self.excess_extracted += len(z.namelist()) - extracted_added
-                                break
+                                extract_exceeded = True
                             except Exception as e:
                                 self.log.error(f"Error while adding extracted content {xml_file_path} for "
                                                f"sample {self.sha}: {str(e)}")

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -55,8 +55,7 @@ class Oletools(ServiceBase):
     # Extensions of interesting files
     FILES_OF_INTEREST = [b'.APK', b'.APP', b'.BAT', b'.BIN', b'.CLASS', b'.CMD', b'.DAT', b'.DLL', b'.EXE',
                          b'.JAR', b'.JS', b'.JSE', b'.LNK', b'.MSI', b'.OSX', b'.PAF', b'.PS1', b'.RAR',
-                         b'.SCR', b'.SWF',b'.SYS', b'.TMP', b'.VBE', b'.VBS', b'.WSF', b'.WSH', b'.ZIP']
-
+                         b'.SCR', b'.SWF', b'.SYS', b'.TMP', b'.VBE', b'.VBS', b'.WSF', b'.WSH', b'.ZIP']
 
     # Safelists
     TAG_SAFELIST = [b"management", b"manager", b"microsoft.com", b"dublincore.org"]
@@ -101,7 +100,7 @@ class Oletools(ServiceBase):
 
         self.macro_section: Optional[ResultSection] = None
 
-        self.word_chains: Optional[Dict[str,Set[str]]] = None
+        self.word_chains: Optional[Dict[str, Set[str]]] = None
         self.macro_skip_words: Set[str] = set()
         self.macro_words_re = re.compile("[a-z]{3,}")
 
@@ -388,7 +387,7 @@ class Oletools(ServiceBase):
                         # good to know that the file types have been detected, but not a score-able offense
                         section.heuristic.add_signature_id(indicator.name)
                     section.add_line(indicator.name + ": " + indicator.description
-                            if indicator.description else indicator.name)
+                                     if indicator.description else indicator.name)
 
             if section.body:
                 self.ole_result.add_section(section)
@@ -500,11 +499,10 @@ class Oletools(ServiceBase):
                         xml_big_res.heuristic.increment_frequency()
                     zip_uris.extend(template_re.findall(data))
 
-                    has_external = external_re.search(data) # Extract all files with external targets
-                    has_dde = dde_re.search(data) # Extract all files with dde links
-                    has_script = script_re.search(data) # Extract all files with javascript
+                    has_external = external_re.search(data)  # Extract all files with external targets
+                    has_dde = dde_re.search(data)  # Extract all files with dde links
+                    has_script = script_re.search(data)  # Extract all files with javascript
                     extract_regex = has_external or has_dde or has_script
-
 
                     # Check for IOC and b64 data in XML
                     iocs, extract_ioc = self.check_for_patterns(data)
@@ -541,7 +539,7 @@ class Oletools(ServiceBase):
 
                 z.close()
 
-                tags_all: List[Tuple[str,bytes]] = []
+                tags_all: List[Tuple[str, bytes]] = []
                 for uri in zip_uris:
                     puri, duri, tag_list = self.parse_uri(uri)
                     if puri:
@@ -556,7 +554,7 @@ class Oletools(ServiceBase):
                     xml_target_res.set_heuristic(38)
                     xml_target_res.add_lines(uris)
                     self.ole_result.add_section(xml_target_res)
-                    #xml_target_res.set_heuristic(1)
+                    # xml_target_res.set_heuristic(1)
 
                 if tags_all:
                     for tag_type, tag in tags_all:
@@ -1310,7 +1308,7 @@ class Oletools(ServiceBase):
 
                     ole_hash = hashlib.sha256(obj.raw).hexdigest()
                     ole_obj_filename = os.path.join(self.working_directory, f"{ole_hash}.pp_ole")
-                    with open(ole_obj_filename, 'w') as fh:
+                    with open(ole_obj_filename, 'wb') as fh:
                         fh.write(obj.raw)
 
                     streams_section.add_line(f"\tPowerPoint Embedded OLE Storage:\n\t\tSHA-256: {ole_hash}\n\t\t"

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -1405,7 +1405,7 @@ class Oletools(ServiceBase):
                 docmeta_sec_json_body[prop] = safe_str(value)
                 # Add Tags
                 if prop in ole_tags and value:
-                    docmeta_sec.add_tag(ole_tags[prop], value)
+                    docmeta_sec.add_tag(ole_tags[prop], safe_str(value))
         if docmeta_sec_json_body:
             docmeta_sec.body = json.dumps(docmeta_sec_json_body)
 

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -1166,7 +1166,7 @@ class Oletools(ServiceBase):
                         subsection.add_line(f"{keyword}: {safe_str(duri)}")
                         subsection.heuristic.increment_frequency()
                     elif desc_ip:
-                        ip_str = desc_ip.group(1)
+                        ip_str = safe_str(desc_ip.group(1))
                         if not is_ip_reserved(ip_str):
                             subsection.heuristic.increment_frequency()
                             subsection.add_tag('network.static.ip', ip_str)

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -492,7 +492,11 @@ class Oletools(ServiceBase):
             if zipfile.is_zipfile(path):
                 z = zipfile.ZipFile(path)
                 for f in z.namelist():
-                    data = z.open(f).read()
+                    try:
+                        data = z.open(f).read()
+                    except zipfile.BadZipFile:
+                        continue
+
                     if len(data) > 500000:
                         data = data[:500000]
                         xml_big_res.add_line(f'{f}')


### PR DESCRIPTION
OleTools doesn't have to process the excess files that don't get appended to the results, it could just take the difference.

AFAIK, it doesn't look like self.excess_extracted is used for anything other than reporting the number of elements in the collection.

@cccs-jh does this seem okay or am I missing something?

This fixes a pre-empt issue I encountered with a sample on staging.