### PR TITLE
Extract links

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -524,12 +524,12 @@ class Oletools(ServiceBase):
         except Exception:
             self.log.warning(f"Failed to analyze zipped file for sample {self.sha}: {traceback.format_exc()}")
 
-        for link_type, link in set(external_links):
-            link_type = safe_str(link_type)
+        for ty, link in set(external_links):
+            link_type = safe_str(ty)
             puri, duri, tag_list = self.parse_uri(link)
             if puri:
                 xml_target_res.add_line(f'{link_type} link: {safe_str(duri)}')
-                xml_target_res.heurisitic.add_signature_id(link_type)
+                xml_target_res.heuristic.add_signature_id(link_type)
             for tag_type, tag in tag_list:
                 if tag_type == 'network.static.ip':
                     xml_target_res.heuristic.add_signature_id('ExternalLinkIP')

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -468,24 +468,23 @@ class Oletools(ServiceBase):
         Args:
             path: Path to original sample.
         """
-        xml_target_res = ResultSection("Attached External Template Targets in XML")
+        xml_target_res = ResultSection("Attached External Template Targets in XML", heuristic=Heuristic(1))
         xml_ioc_res = ResultSection("IOCs content:", heuristic=Heuristic(7, frequency=0))
         xml_b64_res = ResultSection("Base64 content:")
         xml_big_res = ResultSection("Files too large to be fully scanned", heuristic=Heuristic(3, frequency=0))
 
+        external_links: List[Tuple[bytes, bytes]] = []
         ioc_files: Mapping[str, List[str]] = defaultdict(list)
         # noinspection PyBroadException
         try:
-            template_re = re.compile(rb'/(?:attachedTemplate|subDocument)".{1,512}[Tt]arget="((?!file)[^"]+)".{1,512}'
+            external_re = re.compile(rb'/([^"/]+)".{1,512}[Tt]arget="((?!file)[^"]+)".{1,512}'
                                      rb'[Tt]argetMode="External"', re.DOTALL)
-            external_re = re.compile(rb'[Tt]arget="[^"]+".{1,512}[Tt]argetMode="External"', re.DOTALL)
             dde_re = re.compile(rb'ddeLink')
             script_re = re.compile(rb'script.{1,512}("JScript"|javascript)', re.DOTALL)
-            uris = []
-            zip_uris = []
             xml_extracted = set()
-            if zipfile.is_zipfile(path):
-                z = zipfile.ZipFile(path)
+            if not zipfile.is_zipfile(path):
+                return # Not an Open XML format file
+            with zipfile.ZipFile(path) as z:
                 for f in z.namelist():
                     try:
                         data = z.open(f).read()
@@ -496,12 +495,12 @@ class Oletools(ServiceBase):
                         data = data[:500000]
                         xml_big_res.add_line(f'{f}')
                         xml_big_res.heuristic.increment_frequency()
-                    zip_uris.extend(template_re.findall(data))
 
-                    has_external = external_re.search(data)  # Extract all files with external targets
+                    has_external = external_re.findall(data) # Extract all files with external targets
+                    external_links.extend(has_external)
                     has_dde = dde_re.search(data)  # Extract all files with dde links
                     has_script = script_re.search(data)  # Extract all files with javascript
-                    extract_regex = has_external or has_dde or has_script
+                    extract_regex = bool(has_external or has_dde or has_script)
 
                     # Check for IOC and b64 data in XML
                     iocs, extract_ioc = self.check_for_patterns(data)
@@ -522,33 +521,22 @@ class Oletools(ServiceBase):
                         if xml_sha256 not in xml_extracted:
                             self.extract_file(data, xml_sha256, f"zipped file {f} contents")
                             xml_extracted.add(xml_sha256)
-
-                z.close()
-
-                tags_all: List[Tuple[str, bytes]] = []
-                for uri in zip_uris:
-                    puri, duri, tag_list = self.parse_uri(uri)
-                    if puri:
-                        uris.append(safe_str(duri))
-
-                    if tag_list:
-                        tags_all.extend(tag_list)
-
-                uris = list(set(uris))
-                # If there are domains or IPs, report them
-                if uris:
-                    xml_target_res.set_heuristic(38)
-                    xml_target_res.add_lines(uris)
-                    self.ole_result.add_section(xml_target_res)
-                    # xml_target_res.set_heuristic(1)
-
-                if tags_all:
-                    for tag_type, tag in tags_all:
-                        xml_target_res.add_tag(tag_type, tag)
-
         except Exception:
             self.log.warning(f"Failed to analyze zipped file for sample {self.sha}: {traceback.format_exc()}")
 
+        for link_type, link in set(external_links):
+            link_type = safe_str(link_type)
+            puri, duri, tag_list = self.parse_uri(link)
+            if puri:
+                xml_target_res.add_line(f'{link_type} link: {safe_str(duri)}')
+                xml_target_res.heurisitic.add_signature_id(link_type)
+            for tag_type, tag in tag_list:
+                if tag_type == 'network.static.ip':
+                    xml_target_res.heuristic.add_signature_id('ExternalLinkIP')
+                xml_target_res.add_tag(tag_type, tag)
+
+        if external_links:
+            self.ole_result.add_section(xml_target_res)
         if xml_big_res.body:
             self.ole_result.add_section(xml_big_res)
         if xml_ioc_res.tags:
@@ -559,7 +547,7 @@ class Oletools(ServiceBase):
                     xml_ioc_res.add_line('')
                     xml_ioc_res.heuristic.increment_frequency()
             self.ole_result.add_section(xml_ioc_res)
-        if len(xml_b64_res.subsections) > 0:
+        if xml_b64_res.subsections:
             self.ole_result.add_section(xml_b64_res)
 
     @staticmethod

--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -477,7 +477,7 @@ class Oletools(ServiceBase):
         ioc_files: Mapping[str, List[str]] = defaultdict(list)
         # noinspection PyBroadException
         try:
-            external_re = re.compile(rb'/([^"/]+)".{1,512}[Tt]arget="((?!file)[^"]+)".{1,512}'
+            external_re = re.compile(rb'[Tt]ype="[^"]{1,512}/([^"/]+)".{1,512}[Tt]arget="((?!file)[^"]+)".{1,512}'
                                      rb'[Tt]argetMode="External"', re.DOTALL)
             dde_re = re.compile(rb'ddeLink')
             script_re = re.compile(rb'script.{1,512}("JScript"|javascript)', re.DOTALL)
@@ -529,10 +529,10 @@ class Oletools(ServiceBase):
             puri, duri, tag_list = self.parse_uri(link)
             if puri:
                 xml_target_res.add_line(f'{link_type} link: {safe_str(duri)}')
-                xml_target_res.heuristic.add_signature_id(link_type)
+                xml_target_res.heuristic.add_signature_id(link_type.lower())
             for tag_type, tag in tag_list:
                 if tag_type == 'network.static.ip':
-                    xml_target_res.heuristic.add_signature_id('ExternalLinkIP')
+                    xml_target_res.heuristic.add_signature_id('external_link_ip')
                 xml_target_res.add_tag(tag_type, tag)
 
         if external_links:

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -28,12 +28,18 @@ config:
 
 heuristics:
   - heur_id: 1
-    name: Attached Document Template
+    name: External Link
     score: 0
+    signature_score_map:
+      attachedTemplate: 500
+      subDocument: 500
+      frame: 500
+      ExternalLinkIP: 500
     filetype: document/office
     description: >-
-      Attached template specified in xml relationships (pointing to external source).
-      This can be used for malicious purposes.
+      XML relationship with external link as the target.
+      External attached templates, subdocuments, and frames
+      can all be used for malicious purposes.
 
   - heur_id: 2
     name: Multi-embedded documents
@@ -222,12 +228,6 @@ heuristics:
     score: 10
     filetype: document/office
     description: OleID indicator object found
-
-  - heur_id: 38
-    name: Attached External Template Targets in XML
-    score: 500
-    filetype: document/office
-    description: Attached External Template Targets in XML
 
   - heur_id: 40
     name: Root[0] Does Not Exist

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -31,10 +31,10 @@ heuristics:
     name: External Link
     score: 0
     signature_score_map:
-      attachedTemplate: 500
-      subDocument: 500
+      attachedtemplate: 500
+      subdocument: 500
       frame: 500
-      ExternalLinkIP: 500
+      external_link_ip: 500
     filetype: document/office
     description: >-
       XML relationship with external link as the target.


### PR DESCRIPTION
Extracting all external links in xml relationships under a single heuristic.
Default score is 0 (for now) but signatures score based on relationship type,
and another signature adds an additional 500 if the url uses an ip instead of a domain.