### PR TITLE
Parse XML and more external link types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y default-libmysqlclient-dev && rm -rf /v
 # Switch to assemblyline user
 USER assemblyline
 
-RUN pip install --no-cache-dir --user hachoir pcodedmp oletools && rm -rf ~/.cache/pip
+RUN pip install --no-cache-dir --user hachoir lxml pcodedmp oletools && rm -rf ~/.cache/pip
 
 # Copy Oletools service code
 WORKDIR /opt/al_service

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -31,16 +31,28 @@ heuristics:
     name: External Link
     score: 0
     signature_score_map:
+      external_link_ip: 500
+      # relationship types
       attachedtemplate: 500
-      subdocument: 500
+      externallink: 500
+      externallinkpath: 500
+      externalreference: 500
       frame: 500
       hyperlink: 500
-      external_link_ip: 500
+      subdocument: 500
+      officedocument: 500
+      oleobject: 500
+      package: 500
+      slideupdateurl: 500
+      slidemaster: 500
+      slide: 500
+      slideupdateinfo: 500
+      subdocument: 500
+      worksheet: 500
     filetype: document/office
     description: >-
       XML relationship with external link as the target.
-      External attached templates, subdocuments, and frames
-      can all be used for malicious purposes.
+      Many relationship types can be used to link to malicious files.
 
   - heur_id: 2
     name: Multi-embedded documents


### PR DESCRIPTION
Parse XML with lxml to deobfuscate before looking for iocs,
defaulting to the raw text if parsing fails.
Extended list of scored external relationship types with the list
of blacklisted relationship types in oletools