### PR TITLE
Allow detection of external links with mhtml handlers

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -1450,16 +1450,15 @@ class Oletools(ServiceBase):
 
         for ty, link in set(external_links):
             link_type = safe_str(ty)
-            puri, duri, tag_list = self.parse_uri(link)
-            if puri:
-                xml_target_res.add_line(f'{link_type} link: {safe_str(duri)}')
-                xml_target_res.heuristic.add_signature_id(link_type.lower())
-                if link_type.lower() == 'attachedtemplate':
-                    xml_target_res.heuristic.add_attack_id('T1221')
-            for tag_type, tag in tag_list:
-                if tag_type == 'network.static.ip':
-                    xml_target_res.heuristic.add_signature_id('external_link_ip')
-                xml_target_res.add_tag(tag_type, tag)
+            xml_target_res.add_line(f'{link_type} link: {safe_str(link)}')
+            xml_target_res.heuristic.add_signature_id(link_type.lower())
+            if link_type.lower() == 'attachedtemplate':
+                xml_target_res.heuristic.add_attack_id('T1221')
+            if link.startswith(b'mhtml:'):
+                xml_target_res.add_tag('attribution.exploit', 'CVE-2021-40444')
+                xml_target_res.heuristic.add_signature_id('mhtml_handler')
+            if re.search(self.IP_RE, link):
+                xml_target_res.heuristic.add_signature_id('external_link_ip')
 
         if external_links:
             self.ole_result.add_section(xml_target_res)

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -32,6 +32,7 @@ heuristics:
     score: 0
     signature_score_map:
       external_link_ip: 500
+      mhtml_handler: 500
       # relationship types
       attachedtemplate: 500
       externallink: 500


### PR DESCRIPTION
CVE-2021-40444 exploits sometimes use an mhtml handler link of the form "mhtml:https://first.link!x-usc:https://second.link" as the target.