### PR TITLE
Remove score from hyperlinks

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -39,8 +39,7 @@ heuristics:
       externallinkpath: 500
       externalreference: 500
       frame: 500
-      hyperlink: 500
-      subdocument: 500
+      hyperlink: 0
       officedocument: 500
       oleobject: 500
       package: 500


### PR DESCRIPTION
Eternal link hyperlinks can be used by non-malicious documents and
cause false positives.
also subdocument was listed twice which is now fixed