### PR TITLE
Remove msodde error section and remove xml from list of accepted file…

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -305,8 +305,6 @@ class Oletools(ServiceBase):
         # Unicode and other errors common for msodde when parsing samples, do not log under warning
         except Exception as e:
             self.log.debug(f"msodde parsing for sample {self.sha} failed: {str(e)}")
-            section = ResultSection("msodde : Error parsing document")
-            self.ole_result.add_section(section)
 
     def _process_dde_links(self, links_text: str, ole_result: Result) -> None:
         """Examine DDE links and report on malicious characteristics.

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -5,7 +5,7 @@ description: >-
   Microsoft OLE and XML documents using the Python library py-oletools by Philippe
   Lagadec - http://www.decalage.info.
 
-accepts: document/office/.*|code/xml
+accepts: document/office/.*
 rejects: empty|metadata/.*
 
 stage: CORE


### PR DESCRIPTION
…types

Oletools doesn't give useful results on xml and msodde errors are usually
just from an unsupported filetype