### PR TITLE
Remove cve_40444 and lower mhtml score

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -1458,8 +1458,7 @@ class Oletools(ServiceBase):
             if re.search(self.IP_RE, link):
                 xml_target_res.heuristic.add_signature_id('external_link_ip')
             if link.startswith(b'mhtml:'):
-                xml_target_res.add_tag('attribution.exploit', 'CVE-2021-40444')
-                xml_target_res.heuristic.add_signature_id('mhtml_handler')
+                xml_target_res.heuristic.add_signature_id('mhtml_link')
                 # Get last url link
                 link = link.rsplit(b'!x-usc:')[-1]
             url = urlparse(link)

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -35,7 +35,7 @@ heuristics:
     signature_score_map:
       external_relationship_ip: 500
       link_to_executable: 500
-      mhtml_handler: 500
+      mhtml_link: 100
       # relationship types
       attachedtemplate: 500
       externallink: 500


### PR DESCRIPTION
CVE_40444 doesn't always use mhtml links and non-CVE-40444 links
are sometimes mhtml. mhtml false positives have been found