### PR TITLE
False positive checking

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -1935,7 +1935,7 @@ class Oletools(ServiceBase):
             'network.static.uri': [url],
             hostname_type: [hostname]
         }
-        if url.endswith('!'):
+        if url.endswith('!') and link_type.lower() == 'oleobject':
             tags['network.static.uri'].append(url[:-1])
             tags['attribution.exploit'] = ['CVE-2022-30190']
             heuristic.add_signature_id('msdt_exploit')

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -159,7 +159,7 @@ heuristics:
     score: 0
     signature_score_map:
       hexadecimal: 0
-      shellcode: 0 # Set to 1000 if no false positives
+      shellcode: 1000
     filetype: document/office
     description: Large metadata content extracted for analysis.
 

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -37,7 +37,7 @@ heuristics:
       external_relationship_ip: 500
       link_to_executable: 500
       mhtml_link: 100
-      msdt_exploit: 0 # Let's see how many false positives we get
+      msdt_exploit: 500
       # relationship types
       attachedtemplate: 500
       externallink: 500

--- a/test/test_oletools_.py
+++ b/test/test_oletools_.py
@@ -122,6 +122,8 @@ def test_process_link_exclamation_true_positive():
     ole = Oletools()
     ole.start()
     heur, tags = ole._process_link('oleObject',
-                                   R'https://cdn.discordapp.com/attachments/986484515985825795/986821210044264468/index.htm!')
+                                   R'https://cdn.discordapp.com/attachments/98'
+                                   R'6484515985825795/986821210044264468/index.htm!')
     assert 'msdt_exploit' in heur.signatures
-    assert 'https://cdn.discordapp.com/attachments/986484515985825795/986821210044264468/index.htm' in tags['network.static.uri']
+    assert ('https://cdn.discordapp.com/attachments/986484515985825795/986821210044264468/index.htm'
+            in tags['network.static.uri'])

--- a/test/test_oletools_.py
+++ b/test/test_oletools_.py
@@ -107,3 +107,21 @@ def test_process_link_SyncAppvPublishingServer(link: str, heuristic: Heuristic, 
     assert heur.attack_ids == heuristic.attack_ids
     assert heur.signatures == heuristic.signatures
     assert filename in ole._extracted_files
+
+
+def test_process_link_exclamation_false_positive():
+    ole = Oletools()
+    ole.start()
+    heur, _ = ole._process_link('hyperlink',
+                                R'https://domain.com/index.cfm?fuseaction='
+                                R'security.viewSILogon%20%20Login:%20username10%20Password:%20password1!')
+    assert heur.score == 0
+
+
+def test_process_link_exclamation_true_positive():
+    ole = Oletools()
+    ole.start()
+    heur, tags = ole._process_link('oleObject',
+                                   R'https://cdn.discordapp.com/attachments/986484515985825795/986821210044264468/index.htm!')
+    assert 'msdt_exploit' in heur.signatures
+    assert 'https://cdn.discordapp.com/attachments/986484515985825795/986821210044264468/index.htm' in tags['network.static.uri']


### PR DESCRIPTION
Setting the score on signatures previously set to 0 to allow for false positive checking