### PR TITLE
Reject document/office/email

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true,
+        "source.organizeImports": "explicit"
     },
     "editor.formatOnSave": true,
     "editor.rulers": [

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -6,7 +6,7 @@ description: >-
   Lagadec - http://www.decalage.info.
 
 accepts: document/office/.*|document/odt/.*|document/installer/windows
-rejects: empty|metadata/.*
+rejects: empty|metadata/.*|document/office/email
 
 stage: CORE
 category: Static Analysis


### PR DESCRIPTION
As per https://cccs.atlassian.net/browse/AL-2821.
Outlook .msg files are handled better by the EmlParser service.