### PR TITLE
Skip OneNote files

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -6,7 +6,7 @@ description: >-
   Lagadec - http://www.decalage.info.
 
 accepts: document/office/.*|document/odt/.*|document/installer/windows
-rejects: empty|metadata/.*|document/office/email
+rejects: empty|metadata/.*|document/office/email|document/office/onenote
 
 stage: CORE
 category: Static Analysis

--- a/tests/results/012b42e8fed8e109456d6956b1a7974b262e3655ecbb9ecde588a8811b7a67c3/result.json
+++ b/tests/results/012b42e8fed8e109456d6956b1a7974b262e3655ecbb9ecde588a8811b7a67c3/result.json
@@ -75,13 +75,13 @@
               "macro": {
                 "sha256": [
                   "f36d490372e1ef33bbf02c4f72d8aedebf0ac3f4292e288de6162cbc20a7b3c4",
+                  "14de0425a62586687c3d59b7d3d7dc60268f989ab7e07a61403525064d98502a",
                   "8105e1362a2256083c87650bf3f402ea18553abb1bdab2f08f7649859dd02312",
                   "ee5611644b7c99994a401685fb60391337dcd245a8cd9ceab2da0b3afd82bde0",
                   "12a0f7735c6438a01176ea862764077f158f4cf3ceec0025bc7bea6477a8f5e1",
-                  "cd4ccf9c57caf9e1488d28f6b101daa166cef8282c33bb1566da71d568d2a8d0",
-                  "14de0425a62586687c3d59b7d3d7dc60268f989ab7e07a61403525064d98502a",
+                  "c6cd80c393edd2ea268230ae102b228c6076fbc6fa7d1e96ee327c9c4a1fe98d",
                   "81e88462c64c2201a24df7872d6a68a7816c7c002f0a87d05daf6703c6c4fb02",
-                  "c6cd80c393edd2ea268230ae102b228c6076fbc6fa7d1e96ee327c9c4a1fe98d"
+                  "cd4ccf9c57caf9e1488d28f6b101daa166cef8282c33bb1566da71d568d2a8d0"
                 ]
               }
             }
@@ -124,8 +124,8 @@
   "files": {
     "extracted": [
       {
-        "name": "22a4b2fd_all_vba.data",
-        "sha256": "22a4b2fddb77947f433cf7895b99f3b872a5907607b1915e14df1b0a3127c7d1"
+        "name": "1c4c87a9_all_vba.data",
+        "sha256": "1c4c87a97547086ed12234ffe8255844abf296100c4be4e112b15a2bc9bdaf93"
       },
       {
         "name": "eeca6832_all_pcode.data",

--- a/tests/results/c4a2bd3df0baa880dbd6098e0039a4208205c9a021d673e5f5236cf4e8d4175a/result.json
+++ b/tests/results/c4a2bd3df0baa880dbd6098e0039a4208205c9a021d673e5f5236cf4e8d4175a/result.json
@@ -5,7 +5,7 @@
     "sections": [
       {
         "auto_collapse": false,
-        "body": "File format: Generic OLE file / Compound File (unknown format), Unrecognized OLE file. Root CLSID: 000C1084-0000-0000-C000-000000000046 - None\nContainer format: OLE, Container type\nApplication name: b'Cheat Space', Application name declared in properties\nProperties code page: 1252: ANSI Latin 1; Western European (Windows), Code page used for properties\nAuthor: b'Cheat Space Inc.', Author declared in properties",
+        "body": "File format: Windows Installer Package (.msi)\nContainer format: OLE, Container type\nApplication name: b'Cheat Space', Application name declared in properties\nProperties code page: 1252: ANSI Latin 1; Western European (Windows), Code page used for properties\nAuthor: b'Cheat Space Inc.', Author declared in properties",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -100,7 +100,7 @@
       {
         "auto_collapse": false,
         "body": {
-          "000C1084-0000-0000-C000-000000000046": "unknown CLSID"
+          "000C1084-0000-0000-C000-000000000046": "MSI Windows Installer Package (msi)"
         },
         "body_config": {},
         "body_format": "KEY_VALUE",

--- a/tests/results/d7b8caa69d88b7504bb82e8e779404c85d399a1d597a65f91010e840c7b6d733/result.json
+++ b/tests/results/d7b8caa69d88b7504bb82e8e779404c85d399a1d597a65f91010e840c7b6d733/result.json
@@ -5,7 +5,7 @@
     "sections": [
       {
         "auto_collapse": false,
-        "body": "File format: Generic OLE file / Compound File (unknown format), Unrecognized OLE file. Root CLSID: 000C1084-0000-0000-C000-000000000046 - None\nContainer format: OLE, Container type\nApplication name: b'Advanced Installer 12.3 build 64631', Application name declared in properties\nProperties code page: 1252: ANSI Latin 1; Western European (Windows), Code page used for properties\nAuthor: b'Copyright \\xa9 2023', Author declared in properties",
+        "body": "File format: Windows Installer Package (.msi)\nContainer format: OLE, Container type\nApplication name: b'Advanced Installer 12.3 build 64631', Application name declared in properties\nProperties code page: 1252: ANSI Latin 1; Western European (Windows), Code page used for properties\nAuthor: b'Copyright \\xa9 2023', Author declared in properties",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",
@@ -100,7 +100,7 @@
       {
         "auto_collapse": false,
         "body": {
-          "000C1084-0000-0000-C000-000000000046": "unknown CLSID"
+          "000C1084-0000-0000-C000-000000000046": "MSI Windows Installer Package (msi)"
         },
         "body_config": {},
         "body_format": "KEY_VALUE",


### PR DESCRIPTION
OneNote files are neither OLE nor zipped xml, none of the oletools except oleid do anything with one.