### PR TITLE
Detect RTF object update

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -44,10 +44,10 @@ from assemblyline_v4_service.common.request import ServiceRequest
 from assemblyline_v4_service.common.result import BODY_FORMAT, Heuristic, Result, ResultKeyValueSection, ResultSection
 from assemblyline_v4_service.common.task import MaxExtractedExceeded
 from lxml import etree
-from oletools.common import clsid
-from oletools.thirdparty.xxxswf import xxxswf
 
 from oletools import mraptor, msodde, oleid, oleobj, olevba, rtfobj
+from oletools.common import clsid
+from oletools.thirdparty.xxxswf import xxxswf
 from oletools_.cleaver import OLEDeepParser
 from oletools_.stream_parser import PowerPointDoc
 
@@ -1196,6 +1196,16 @@ class Oletools(ServiceBase):
         streams_res = ResultSection("RTF objects")
         if rtf_template_res:
             _add_subsection(streams_res, rtf_template_res)
+
+        if b"\\objupdate" in file_contents:
+            streams_res.add_subsection(
+                ResultSection(
+                    "RTF Object Update",
+                    "RTF Object uses \\objectupdate to update before being displayed."
+                    " This can be used maliciously to load an object without user interaction.",
+                    heuristic=Heuristic(54),
+                )
+            )
 
         sep = "-----------------------------------------"
         embedded = []

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -378,6 +378,13 @@ heuristics:
     signature_score_map:
       zip_concatenation: 500
 
+  - heur_id: 54
+    name: RTF Object Update
+    # TODO: Evaluate fpos rate
+    score: 500
+    filetype: "document/office/rtf"
+    description: "RTF Object uses \\objectupdate to load without user interaction."
+
 docker_config:
   image: ${REGISTRY}cccs/assemblyline-service-oletools:$SERVICE_TAG
   cpu_cores: 1.0

--- a/tests/results/ab1a6d657eff3d3eb8927d5dab552f15e8783ae738a604db7630d4356d2b48b9/result.json
+++ b/tests/results/ab1a6d657eff3d3eb8927d5dab552f15e8783ae738a604db7630d4356d2b48b9/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 1010,
+    "score": 1510,
     "sections": [
       {
         "auto_collapse": false,
@@ -45,6 +45,26 @@
       },
       {
         "auto_collapse": false,
+        "body": "RTF Object uses \\objectupdate to update before being displayed. This can be used maliciously to load an object without user interaction.",
+        "body_config": {},
+        "body_format": "TEXT",
+        "classification": "TLP:C",
+        "depth": 1,
+        "heuristic": {
+          "attack_ids": [],
+          "frequency": 1,
+          "heur_id": 54,
+          "score": 500,
+          "score_map": {},
+          "signatures": {}
+        },
+        "promote_to": null,
+        "tags": {},
+        "title_text": "RTF Object Update",
+        "zeroize_on_tag_safe": false
+      },
+      {
+        "auto_collapse": false,
         "body": "0x8b is not a well-formed OLE object\nMalicious Properties found: Data of malformed OLE object over 5000 bytes",
         "body_config": {},
         "body_format": "MEMORY_DUMP",
@@ -84,6 +104,11 @@
       {
         "attack_ids": [],
         "heur_id": 34,
+        "signatures": []
+      },
+      {
+        "attack_ids": [],
+        "heur_id": 54,
         "signatures": []
       }
     ],


### PR DESCRIPTION
\objupdate is used a lot to avoid user interaction in RTF campaigns, to the point that the first search results for "\objupdate" are all reports on malware.