### PR TITLE
Improvements to embedded ole handling

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -366,7 +366,7 @@ heuristics:
 
   - heur_id: 52
     name: Known malicious CLSID
-    score: 500
+    score: 250
     filetype: ".*"
     description: CLSID that has been flagged as malicious
 

--- a/tests/results/2ccf170ae2be29186c44ef1af4fa94a3c934e292c47099de6150599f00a476ab/result.json
+++ b/tests/results/2ccf170ae2be29186c44ef1af4fa94a3c934e292c47099de6150599f00a476ab/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 517,
+    "score": 267,
     "sections": [
       {
         "auto_collapse": false,
@@ -86,7 +86,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 52,
-          "score": 500,
+          "score": 250,
           "score_map": {},
           "signatures": {}
         },
@@ -221,6 +221,10 @@
   },
   "files": {
     "extracted": [
+      {
+        "name": "f0df4a7b.Uwo2WUa",
+        "sha256": "f0df4a7be1537174c64a7701d63de965f663dd0df70a4351499d3202ecf9b49d"
+      },
       {
         "name": "f0df4a7b.xml",
         "sha256": "f0df4a7be1537174c64a7701d63de965f663dd0df70a4351499d3202ecf9b49d"

--- a/tests/results/44e593c98acaf52aee91c09fe00fa196668351783fc8a623fc1da5325635130f/result.json
+++ b/tests/results/44e593c98acaf52aee91c09fe00fa196668351783fc8a623fc1da5325635130f/result.json
@@ -194,26 +194,6 @@
       },
       {
         "auto_collapse": false,
-        "body": null,
-        "body_config": {},
-        "body_format": "TEXT",
-        "classification": "TLP:C",
-        "depth": 0,
-        "heuristic": {
-          "attack_ids": [],
-          "frequency": 1,
-          "heur_id": 2,
-          "score": 0,
-          "score_map": {},
-          "signatures": {}
-        },
-        "promote_to": null,
-        "tags": {},
-        "title_text": "Embedded OLE files",
-        "zeroize_on_tag_safe": false
-      },
-      {
-        "auto_collapse": false,
         "body": "Macro may be packed or obfuscated.",
         "body_config": {},
         "body_format": "TEXT",
@@ -342,11 +322,6 @@
   },
   "results": {
     "heuristics": [
-      {
-        "attack_ids": [],
-        "heur_id": 2,
-        "signatures": []
-      },
       {
         "attack_ids": [],
         "heur_id": 9,

--- a/tests/results/65f44c60c71ea9b09d765c55b91e168a8b60ea76304c7bf3f4bf5d7e666c4b42/result.json
+++ b/tests/results/65f44c60c71ea9b09d765c55b91e168a8b60ea76304c7bf3f4bf5d7e666c4b42/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 514,
+    "score": 264,
     "sections": [
       {
         "auto_collapse": false,
@@ -62,7 +62,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 52,
-          "score": 500,
+          "score": 250,
           "score_map": {},
           "signatures": {}
         },
@@ -242,6 +242,10 @@
   },
   "files": {
     "extracted": [
+      {
+        "name": "5a0b6e3e.uJCV2",
+        "sha256": "5a0b6e3eb8c931fded7e6c0836271f47041cb0f4309ff79d9f135da749cc8b89"
+      },
       {
         "name": "5a0b6e3e.xml",
         "sha256": "5a0b6e3eb8c931fded7e6c0836271f47041cb0f4309ff79d9f135da749cc8b89"

--- a/tests/results/ab1a6d657eff3d3eb8927d5dab552f15e8783ae738a604db7630d4356d2b48b9/result.json
+++ b/tests/results/ab1a6d657eff3d3eb8927d5dab552f15e8783ae738a604db7630d4356d2b48b9/result.json
@@ -45,7 +45,7 @@
       },
       {
         "auto_collapse": false,
-        "body": "RTF Object uses \\objectupdate to update before being displayed. This can be used maliciously to load an object without user interaction.",
+        "body": "RTF Object uses \\objupdate to update before being displayed. This can be used maliciously to load an object without user interaction.",
         "body_config": {},
         "body_format": "TEXT",
         "classification": "TLP:C",

--- a/tests/results/ec82959bb9c34cfbbd6fbfcb8afce89ba25f09722fc4996d0d16f64368ee67e4/result.json
+++ b/tests/results/ec82959bb9c34cfbbd6fbfcb8afce89ba25f09722fc4996d0d16f64368ee67e4/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 510,
+    "score": 260,
     "sections": [
       {
         "auto_collapse": false,
@@ -73,7 +73,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 52,
-          "score": 500,
+          "score": 250,
           "score_map": {},
           "signatures": {}
         },

--- a/tests/results/f0df4a7be1537174c64a7701d63de965f663dd0df70a4351499d3202ecf9b49d/result.json
+++ b/tests/results/f0df4a7be1537174c64a7701d63de965f663dd0df70a4351499d3202ecf9b49d/result.json
@@ -1,7 +1,7 @@
 {
   "extra": {
     "drop_file": false,
-    "score": 513,
+    "score": 263,
     "sections": [
       {
         "auto_collapse": false,
@@ -73,7 +73,7 @@
           "attack_ids": [],
           "frequency": 1,
           "heur_id": 52,
-          "score": 500,
+          "score": 250,
           "score_map": {},
           "signatures": {}
         },


### PR DESCRIPTION
- Lower Known malicious CLSID score, many CVE are old and false positive rate is high
- Extract OLE embedded in zip, these tend to be interesting files, and there aren't that many
- Only flag heuristic 2 if there is OLE in zip, many .doc/.xls files have a zip for theme data