### PR TITLE
Fix truncated UNC path URI tags

### DIFF
--- a/oletools_/oletools_.py
+++ b/oletools_/oletools_.py
@@ -2294,11 +2294,11 @@ class Oletools(ServiceBase):
             safe_link = safe_link.rsplit("!x-usc:")[-1]
             # Strip the mhtml path
             safe_link = safe_link.rsplit("!", 1)[0]
-        if unescaped.startswith(R"file:///\\"):
+        if safe_link.startswith(R"file:///\\"):
             # UNC file path
             heuristic.add_signature_id("unc_path")
             # Convert to normal file uri
-            safe_link = PureWindowsPath(unescaped[8:].split()[0]).as_uri()
+            safe_link = PureWindowsPath(unquote(safe_link[8:].split()[0])).as_uri()
         url, hostname_type, hostname = self.parse_uri(safe_link)
         if not hostname:
             # Not a valid link

--- a/tests/test_oletools_.py
+++ b/tests/test_oletools_.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 from assemblyline_v4_service.common.result import Heuristic
+
 from oletools import mraptor, msodde, oleid, oleobj, olevba, rtfobj
 from oletools_.oletools_ import Oletools, Tags
 
@@ -129,6 +130,16 @@ def test_parse_uri(uri, output):
                     "http://037777777777OOOOOLLLLLLLL000000000000LLLLLLLOOOOO00000000000LLLLLLLOOOOO"
                     "0000000000LLLLL00000000000OOOLLLLLLL@134744072/x......xx.......doc"
                 ],
+            },
+        ),
+        # Percent encoded UNC path
+        (
+            "externalLinkPath",
+            R"file:///\\domain.com\path\percent%20encoded%20file.xlsx",
+            Heuristic(1, signatures={"externallinkpath": 1, "unc_path": 1}),
+            {
+                "network.static.domain": ["domain.com"],
+                "network.static.uri": ["file://domain.com/path/percent%20encoded%20file.xlsx"],
             },
         ),
     ],


### PR DESCRIPTION
URI must be split before decoding or percent encoded spaces can truncate the path.