### PR TITLE
Add Certificate parsing for MSI bundles

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -385,6 +385,12 @@ heuristics:
     filetype: "document/office/rtf"
     description: "RTF Object uses \\objupdate to load without user interaction."
 
+  - heur_id: 55
+    name: Signed OLE Object
+    score: 0
+    filetype: ".*"
+    description: "The OLE object has a code-siging signature."
+
 docker_config:
   image: ${REGISTRY}cccs/assemblyline-service-oletools:$SERVICE_TAG
   cpu_cores: 1.0


### PR DESCRIPTION
Hi, the following implements [a fork of signify](https://github.com/ralphje/signify/pull/50) to parse code-signing certificates in MSI bundles. I merged the fork into my own project and made some tweaks. I plan to recommend some of the changes to the main repository. My fork with the changes I used for testing are here https://github.com/Squiblydoo/signify.

At this time, the changes to oletools.py extracts the most important parts of the code-signing certificate. However, for the sake of completeness, the existing code could be used to extract additional elements such as countersigners. 

Note:
One thing I have yet to do is to ensure that `signify` parses the most important OID in code-signing certificates.  At this time, they only parse a short list of OID, so I plan to assess which additional OID need to be parsed. I am happy to evaluate those and suggest them to the main `signify` repository.
The MSI fork of `signify` is still under evaluation. My only changes beyond the MSI implementation were to 

1. Augment the existing OID list
2. Add a new capability to parse raw certificates. (Signify as to load the whole PE or MSI file, so my change allows us to pass only the certificate.)
3. Add imports to the __init__.py to allow for better integration.

I will also plan to make a pull request for these changes as well.

Please let me know if you have any questions and feel free to adjust the code as needed.